### PR TITLE
Remove OGL licence from footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@companieshouse/ch-node-utils": "^2.1.10",
         "@companieshouse/structured-logging-node": "^2.0.4",
         "express": "^4.21.2",
-        "govuk-frontend": "5.13.0",
+        "govuk-frontend": "5.14.0",
         "nunjucks": "^3.2.4"
       },
       "devDependencies": {
@@ -7547,9 +7547,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.13.0.tgz",
-      "integrity": "sha512-6N3pHelWN7wftdM6e4YEzZAfattapa1gnd+Al6d5PUbfTr9D+T2dnphpNpjX75CTEhihlQqlL0RDQ3WIfZ3PSg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
+      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@companieshouse/ch-node-utils": "^2.1.10",
     "@companieshouse/structured-logging-node": "^2.0.4",
     "express": "^4.21.2",
-    "govuk-frontend": "5.13.0",
+    "govuk-frontend": "5.14.0",
     "nunjucks": "^3.2.4"
   },
   "devDependencies": {

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -29,5 +29,6 @@
       }
     ],
     html: 'Built by <a href="https://www.gov.uk/government/organisations/companies-house" class="govuk-footer__link">Companies House</a>'
-  }
+  },
+  contentLicence: null
 }) }}


### PR DESCRIPTION
Companies House uses a different licence than OGL, in version 5.14.0 of GOV.UK Frontend we can now remove it while still using the Nunjucks macro for the GOV.UK footer component